### PR TITLE
Add support for the Xbox Series X|S Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Credit: This project heavily relies on https://github.com/mzyy94/nscon.
 1. Connect a joystick (only the following ones are supported and tested) to a host PC.
     1. Nintendo Pro controller
     1. X-Box One controller
+    1. Xbox Series X|S controller
     1. PS4 controller
 
 1. On the host PC, install the software:

--- a/nscontroller/cmd/nsbackend/nsbackend.go
+++ b/nscontroller/cmd/nsbackend/nsbackend.go
@@ -99,6 +99,10 @@ func mainLoop(con *nscon.Controller) (err error) {
 			con.Input.Button.Minus = darg
 		case "p": // plus
 			con.Input.Button.Plus = darg
+		case "-": // Minus alternative
+			con.Input.Button.Minus = darg
+		case "+": // plus alternative
+			con.Input.Button.Plus = darg
 
 		case "l1": // L1
 			con.Input.Button.L = darg

--- a/nscontroller/cmd/nsfrontend/nsfrontend.go
+++ b/nscontroller/cmd/nsfrontend/nsfrontend.go
@@ -18,7 +18,8 @@ var (
 )
 
 func mustGetDispatcher(js *js.Js) nscontroller.JoystickDispatcher {
-	if strings.Contains(js.Name, "X-Box One") {
+	if strings.Contains(js.Name, "X-Box One") || strings.Contains(js.Name, "Xbox") {
+		// Xbox string is for the Xbox Series X|S Controller
 		return nscontroller.XBoxOneJoystickDispatcher
 	}
 	if strings.Contains(js.Name, "Nintendo Switch Pro Controller") {


### PR DESCRIPTION
While the Xbox Series X|S Controller works mostly the same as the
Xbox One controller, +/- buttons are reported differently,
as well as the device name.

Signed-off-by: Antonio Torres Moríñigo <atorresm@protonmail.com>